### PR TITLE
Allow reading api key from environment variable

### DIFF
--- a/src/python/ai_code_pal.py
+++ b/src/python/ai_code_pal.py
@@ -1,7 +1,8 @@
 import requests
+import os
 
 def get_chatgpt_suggestion(code_snippet):
-    api_key = "YOUR_API_KEY"
+    api_key = os.environ.get('OPENAI_API_KEY')
     url = "https://api.openai.com/v1/engines/davinci-codex/completions"
     headers = {
         "Content-Type": "application/json",


### PR DESCRIPTION
Perhaps having users modify the library code isn't best practice. This small suggestion uses an environment variable to get the OpenAI API token instead.